### PR TITLE
First version of zone support

### DIFF
--- a/svg_templates/canvas.svg
+++ b/svg_templates/canvas.svg
@@ -94,6 +94,16 @@
             fill: gray;
         }
 
+        .zone {
+            stroke-dasharray: 15;
+            stroke-linejoin: round;
+            stroke-linecap: round;
+        }
+        
+        .zone.secured {
+          stroke: green;
+        }
+        
         $css
     </style>
     <defs>

--- a/test_files/0605-isle.md
+++ b/test_files/0605-isle.md
@@ -9,4 +9,5 @@ terrain:
             - Q
 rivers: 
     - C NE
+zone: secured
 ---

--- a/test_files/0706-isle.md
+++ b/test_files/0706-isle.md
@@ -10,4 +10,6 @@ terrain:
             - C
             - NE
 alt: Baie
+zone:
+    - secured
 ---


### PR DESCRIPTION
This is a draft (yet effective) implementation for #3 .

What is done : 

- [x]  Fix rounding issues ( at least for external points of hexagons)
- [x] Detects clusters
- [x] Draws boundaries around clusters.

However there is still some issues : 

- [ ] the drawing algorithm is implemented in hexamap.py yet it would be better in HexagonGrid; but it cannot be placed there as it would add an impossible circle dependency between Hexagon and HexagonGrid. 

Is it really a good idea to have Hexagon know it's grid? I would have expected the opposite. (In fact I half expected to see HexagonGrid implement the factory pattern to produce hexagon. (so that every Hexagon is registered in it's grid. ) 
@Ezian WDYT ?